### PR TITLE
Use license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,5 @@
     "type": "git",
     "url": "http://github.com/webpack/extract-text-webpack-plugin.git"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
Array deprecated in `npm@2.10.0`

https://github.com/npm/npm/blob/master/doc/files/package.json.md#license