### PR TITLE
Fix import url order

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,12 @@ function getModuleCssImportOrder (module) {
 }
 
 function getOrder(a, b) {
+	// fix ---- http://stackoverflow.com/a/14676665/1458162 ----- begin
+	var aImportOrder = getModuleCssImportOrder(a);
+	var bImportOrder = getModuleCssImportOrder(b);
+	if (aImportOrder < bImportOrder) return -1;
+	if (aImportOrder > bImportOrder) return 1;
+	// fix ---- http://stackoverflow.com/a/14676665/1458162 ----- end
 	var aIndex = a.getOriginalModule().index2;
 	var bIndex = b.getOriginalModule().index2;
 	if(aIndex < bIndex) return -1;

--- a/index.js
+++ b/index.js
@@ -81,6 +81,11 @@ function isInvalidOrder(a, b) {
 	return aBeforeB && bBeforeA;
 }
 
+function getModuleCssImportOrder (module) {
+	var hasCssImport = /^@import url/.test(module._source);
+	return hasCssImport ? -1 : 1;
+}
+
 function getOrder(a, b) {
 	var aIndex = a.getOriginalModule().index2;
 	var bIndex = b.getOriginalModule().index2;


### PR DESCRIPTION
Hi @sokra ,

This bug causes `@import url()` statements being inserted in the middle of the source, which breaks the import behavior. See: http://stackoverflow.com/a/14676665/1458162

Adding a check for css import fixed this issue. Please help review the code cause I'm not sure if using `module._source` is a good idea.

Thanks
