### PR TITLE
Support loaders specified as an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,19 +127,19 @@ ExtractTextPlugin.loader = function(options) {
 };
 
 ExtractTextPlugin.extract = function(before, loader, options) {
-	if(typeof loader === "string") {
+	if(typeof loader === "string" || Array.isArray(loader)) {
+		if(typeof before === "string") {
+			before = before.split("!")
+		}
 		return [
-			ExtractTextPlugin.loader(mergeOptions({omit: before.split("!").length, extract: true, remove: true}, options)),
-			before,
-			loader
-		].join("!");
+			ExtractTextPlugin.loader(mergeOptions({omit: before.length, extract: true, remove: true}, options))
+		].concat(before, loader).join("!");
 	} else {
 		options = loader;
 		loader = before;
 		return [
 			ExtractTextPlugin.loader(mergeOptions({remove: true}, options)),
-			loader
-		].join("!");
+		].concat(loader).join("!");
 	}
 };
 

--- a/index.js
+++ b/index.js
@@ -161,19 +161,19 @@ ExtractTextPlugin.prototype.loader = function(options) {
 };
 
 ExtractTextPlugin.prototype.extract = function(before, loader, options) {
-	if(typeof loader === "string") {
+	if(typeof loader === "string" || Array.isArray(loader)) {
+		if(typeof before === "string") {
+			before = before.split("!")
+		}
 		return [
-			this.loader(mergeOptions({omit: before.split("!").length, extract: true, remove: true}, options)),
-			before,
-			loader
-		].join("!");
+			ExtractTextPlugin.loader(mergeOptions({omit: before.length, extract: true, remove: true}, options))
+		].concat(before, loader).join("!");
 	} else {
 		options = loader;
 		loader = before;
 		return [
-			this.loader(mergeOptions({remove: true}, options)),
-			loader
-		].join("!");
+			ExtractTextPlugin.loader(mergeOptions({remove: true}, options)),
+		].concat(loader).join("!");
 	}
 };
 


### PR DESCRIPTION
Current if the loaders are specified as an array, then extract will
assume they are the options. If the `notExtractLoader` is specified as
an array then there will be an error when trying to split it.

It might be best to only support this change if `loaders:` is used
instead of `loader:` but even solving that problem at all seems to be
a larger issue. This at least allows for using an array of loaders
even if it still must be in a `loader:` context.