### PR TITLE
Fix: Add dependency for webpack-sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "async": "^1.5.0",
-    "loader-utils": "^0.2.3"
+    "loader-utils": "^0.2.3",
+    "webpack-sources": "^0.1.0"
   },
   "devDependencies": {
     "codecov.io": "^0.1.2",


### PR DESCRIPTION
Version 1.0.0 depends on `webpack-sources`, but it does not specify this in `package.json`. See 39d9cc85388c64ed775d09d467c49bd577b50e8b.

```
03 01 2016 22:10:04.273:ERROR [config]: Invalid config file!
  Error: Cannot find module 'webpack-sources'
    at Function.Module._resolveFilename (module.js:327:15)
    at Function.Module._load (module.js:278:25)
```