### PR TITLE
Update webpack dependency to support 2.1.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Extract text from bundle into a file.",
   "peerDependencies": {
-    "webpack": "^1.9.11"
+    "webpack": "^1.9.11 || ^2.1.0-beta"
   },
   "dependencies": {
     "async": "^1.5.0",


### PR DESCRIPTION
Mimicking the babel-loader package.json, update the webpack peer dependency to support the 2.1.0-beta.