### PR TITLE
fix(symlink): node v6 symlink resolve update

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -1,3 +1,4 @@
+var fs = require('fs');
 var webpack = require("webpack");
 var ExtractTextPlugin = require("../");
 module.exports = {
@@ -8,7 +9,7 @@ module.exports = {
 	output: {
 		filename: "[name].js?[hash]-[chunkhash]",
 		chunkFilename: "[name].js?[hash]-[chunkhash]",
-		path: __dirname + "/assets",
+		path: fs.realpathSync(__dirname) + "/assets",
 		publicPath: "/assets/"
 	},
 	module: {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+var fs = require('fs');
 var ConcatSource = require("webpack-sources").ConcatSource;
 var async = require("async");
 var ExtractedModule = require("./ExtractedModule");
@@ -181,16 +182,16 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 	compiler.plugin("this-compilation", function(compilation) {
 		var extractCompilation = new ExtractTextPluginCompilation();
 		compilation.plugin("normal-module-loader", function(loaderContext, module) {
-			loaderContext[__dirname] = function(content, opt) {
+			loaderContext[fs.realpathSync(__dirname)] = function(content, opt) {
 				if(options.disable)
 					return false;
 				if(!Array.isArray(content) && content !== null)
 					throw new Error("Exported value is not a string.");
-				module.meta[__dirname] = {
+				module.meta[fs.realpathSync(__dirname)] = {
 					content: content,
 					options: opt || {}
 				};
-				return options.allChunks || module.meta[__dirname + "/extract"]; // eslint-disable-line no-path-concat
+				return options.allChunks || module.meta[fs.realpathSync(__dirname) + "/extract"]; // eslint-disable-line no-path-concat
 			};
 		});
 		var filename = this.filename;
@@ -238,17 +239,17 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 				var extractedChunk = extractedChunks[chunks.indexOf(chunk)];
 				var shouldExtract = !!(options.allChunks || chunk.initial);
 				async.forEach(chunk.modules.slice(), function(module, callback) {
-					var meta = module.meta && module.meta[__dirname];
+					var meta = module.meta && module.meta[fs.realpathSync(__dirname)];
 					if(meta && (!meta.options.id || meta.options.id === id)) {
 						var wasExtracted = Array.isArray(meta.content);
 						if(shouldExtract !== wasExtracted) {
-							module.meta[__dirname + "/extract"] = shouldExtract; // eslint-disable-line no-path-concat
+							module.meta[fs.realpathSync(__dirname) + "/extract"] = shouldExtract; // eslint-disable-line no-path-concat
 							compilation.rebuildModule(module, function(err) {
 								if(err) {
 									compilation.errors.push(err);
 									return callback();
 								}
-								meta = module.meta[__dirname];
+								meta = module.meta[fs.realpathSync(__dirname)];
 								if(!Array.isArray(meta.content)) {
 									err = new Error(module.identifier() + " doesn't export content");
 									compilation.errors.push(err);

--- a/loader.js
+++ b/loader.js
@@ -2,6 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+var fs = require('fs');
 var loaderUtils = require("loader-utils");
 var NodeTemplatePlugin = require("webpack/lib/node/NodeTemplatePlugin");
 var NodeTargetPlugin = require("webpack/lib/node/NodeTargetPlugin");
@@ -17,14 +18,14 @@ module.exports.pitch = function(request) {
 	var query = loaderUtils.parseQuery(this.query);
 	this.addDependency(this.resourcePath);
 	// We already in child compiler, return empty bundle
-	if(this[__dirname] === undefined) {
+	if(this[fs.realpathSync(__dirname)] === undefined) {
 		throw new Error(
 			'"extract-text-webpack-plugin" loader is used without the corresponding plugin, ' +
 			'refer to https://github.com/webpack/extract-text-webpack-plugin for the usage example'
 		);
-	} else if(this[__dirname] === false) {
+	} else if(this[fs.realpathSync(__dirname)] === false) {
 		return "";
-	} else if(this[__dirname](null, query)) {
+	} else if(this[fs.realpathSync(__dirname)](null, query)) {
 		if(query.omit) {
 			this.loaderIndex += +query.omit + 1;
 			request = request.split("!").slice(+query.omit).join("!");
@@ -49,7 +50,7 @@ module.exports.pitch = function(request) {
 			childCompiler.apply(new NodeTargetPlugin());
 			childCompiler.apply(new SingleEntryPlugin(this.context, "!!" + request));
 			childCompiler.apply(new LimitChunkCountPlugin({ maxChunks: 1 }));
-			var subCache = "subcache " + __dirname + " " + request; // eslint-disable-line no-path-concat
+			var subCache = "subcache " + fs.realpathSync(__dirname) + " " + request; // eslint-disable-line no-path-concat
 			childCompiler.plugin("compilation", function(compilation) {
 				if(compilation.cache) {
 					if(!compilation.cache[subCache])
@@ -57,11 +58,11 @@ module.exports.pitch = function(request) {
 					compilation.cache = compilation.cache[subCache];
 				}
 			});
-			// We set loaderContext[__dirname] = false to indicate we already in
+			// We set loaderContext[fs.realpathSync(__dirname)] = false to indicate we already in
 			// a child compiler so we don't spawn another child compilers from there.
 			childCompiler.plugin("this-compilation", function(compilation) {
 				compilation.plugin("normal-module-loader", function(loaderContext) {
-					loaderContext[__dirname] = false;
+					loaderContext[fs.realpathSync(__dirname)] = false;
 				});
 			});
 			var source;
@@ -104,7 +105,7 @@ module.exports.pitch = function(request) {
 								item[0] = module.identifier();
 						});
 					});
-					this[__dirname](text, query);
+					this[fs.realpathSync(__dirname)](text, query);
 					if(text.locals && typeof resultSource !== "undefined") {
 						resultSource += "\nmodule.exports = " + JSON.stringify(text.locals) + ";";
 					}
@@ -117,7 +118,7 @@ module.exports.pitch = function(request) {
 					callback();
 			}.bind(this));
 		} else {
-			this[__dirname]("", query);
+			this[fs.realpathSync(__dirname)]("", query);
 			return resultSource;
 		}
 	}

--- a/test/TestCases.test.js
+++ b/test/TestCases.test.js
@@ -5,13 +5,13 @@ var webpack = require("webpack");
 var should = require("should");
 var ExtractTextPlugin = require("../");
 
-var cases = fs.readdirSync(path.join(__dirname, "cases"));
+var cases = fs.readdirSync(path.join(fs.realpathSync(__dirname), "cases"));
 
 describe("TestCases", function() {
 	cases.forEach(function(testCase) {
 		it(testCase, function(done) {
-			var testDirectory = path.join(__dirname, "cases", testCase);
-			var outputDirectory = path.join(__dirname, "js", testCase);
+			var testDirectory = path.join(fs.realpathSync(__dirname), "cases", testCase);
+			var outputDirectory = path.join(fs.realpathSync(__dirname), "js", testCase);
 			var options = { entry: { test: "./index.js" } };
 			var configFile = path.join(testDirectory, "webpack.config.js");
 			if(fs.existsSync(configFile))


### PR DESCRIPTION
Node v6 does not resolve symlink anymore using __dirname. This pull fixes error messages like:
```
Module build failed: Error: "extract-text-webpack-plugin" loader is used without the corresponding plugin, refer to https://github.com/webpack/extract-text-webpack-plugin for the usage example
```
when node_modules is symlinked.