### PR TITLE
allowing webpack 2.1.0-beta as a peerdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Extract text from bundle into a file.",
   "peerDependencies": {
-    "webpack": "^1.9.11"
+    "webpack": "^1.9.11 || >=2.1.0-beta"
   },
   "dependencies": {
     "async": "^1.5.0",


### PR DESCRIPTION
All specs pass when I use webpack 2.1.0-beta.