### PR TITLE
[Not ready to merge] Fix WebPack 2 query object in loader chain

### DIFF
--- a/example/webpack2.config.js
+++ b/example/webpack2.config.js
@@ -1,0 +1,33 @@
+var webpack = require("webpack");
+var ExtractTextPlugin = require("../");
+module.exports = {
+	entry: {
+		a: "./entry.js",
+		b: "./entry2.js"
+	},
+	output: {
+		filename: "[name].js?[hash]-[chunkhash]",
+		chunkFilename: "[name].js?[hash]-[chunkhash]",
+		path: __dirname + "/assets",
+		publicPath: "/assets/"
+	},
+	module: {
+		loaders: [
+			{ test: /\.css$/, loaders: [
+				"style-loader",
+				{ loader: "css-loader", query: {
+					sourceMap: true
+				} }
+			]},
+			{ test: /\.png$/, loader: "file-loader" }
+		]
+	},
+	devtool: "source-map",
+	plugins: [
+		new ExtractTextPlugin("css/[name].css?[hash]-[chunkhash]-[contenthash]-[name]", {
+			disable: false,
+			allChunks: true
+		}),
+		new webpack.optimize.CommonsChunkPlugin({name:"c", filename:"c.js"})
+	]
+};

--- a/example/webpack2.config.js
+++ b/example/webpack2.config.js
@@ -13,12 +13,15 @@ module.exports = {
 	},
 	module: {
 		loaders: [
-			{ test: /\.css$/, loaders: [
+			{ test: /\.css$/, loader: ExtractTextPlugin.extract(
 				"style-loader",
 				{ loader: "css-loader", query: {
 					sourceMap: true
-				} }
-			]},
+				} },
+				{
+					publicPath: "../"
+				}
+			)},
 			{ test: /\.png$/, loader: "file-loader" }
 		]
 	},

--- a/example/webpack2.config.js
+++ b/example/webpack2.config.js
@@ -13,15 +13,13 @@ module.exports = {
 	},
 	module: {
 		loaders: [
-			{ test: /\.css$/, loader: ExtractTextPlugin.extract(
-				"style-loader",
-				{ loader: "css-loader", query: {
+			{ test: /\.css$/, loader: ExtractTextPlugin.extract({
+				notExtractLoader: "style-loader",
+				loader: { loader: "css-loader", query: {
 					sourceMap: true
 				} },
-				{
-					publicPath: "../"
-				}
-			)},
+				publicPath: "../"
+			})},
 			{ test: /\.png$/, loader: "file-loader" }
 		]
 	},

--- a/index.js
+++ b/index.js
@@ -125,23 +125,6 @@ ExtractTextPlugin.loader = function(options) {
 	return require.resolve("./loader") + (options ? "?" + JSON.stringify(options) : "");
 };
 
-ExtractTextPlugin.extract = function(before, loader, options) {
-	if(typeof loader === "string" || Array.isArray(loader)) {
-		if(typeof before === "string") {
-			before = before.split("!");
-		}
-		return [
-			ExtractTextPlugin.loader(mergeOptions({omit: before.length, extract: true, remove: true}, options))
-		].concat(before, loader).join("!");
-	} else {
-		options = loader;
-		loader = before;
-		return [
-			ExtractTextPlugin.loader(mergeOptions({remove: true}, options))
-		].concat(loader).join("!");
-	}
-};
-
 ExtractTextPlugin.prototype.applyAdditionalInformation = function(source, info) {
 	if(info) {
 		return new ConcatSource(
@@ -175,6 +158,8 @@ ExtractTextPlugin.prototype.extract = function(before, loader, options) {
 		].concat(loader).join("!");
 	}
 };
+
+ExtractTextPlugin.extract = ExtractTextPlugin.prototype.extract.bind(ExtractTextPlugin);
 
 ExtractTextPlugin.prototype.apply = function(compiler) {
 	var options = this.options;

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ function getOrder(a, b) {
 }
 
 function ExtractTextPlugin(id, filename, options) {
-	if(typeof filename !== "string") {
+	if(!isString(filename)) {
 		options = filename;
 		filename = id;
 		id = ++nextId;
@@ -119,6 +119,10 @@ function mergeOptions(a, b) {
 		a[key] = b[key];
 	});
 	return a;
+}
+
+function isString(a) {
+	return typeof a === "string";
 }
 
 ExtractTextPlugin.loader = function(options) {
@@ -142,21 +146,36 @@ ExtractTextPlugin.prototype.loader = function(options) {
 	return ExtractTextPlugin.loader(options);
 };
 
-ExtractTextPlugin.prototype.extract = function(before, loader, options) {
-	if(typeof loader === "string" || Array.isArray(loader)) {
-		if(typeof before === "string") {
-			before = before.split("!");
-		}
-		return [
-			this.loader(mergeOptions({omit: before.length, extract: true, remove: true}, options))
-		].concat(before, loader).join("!");
-	} else {
-		options = loader;
-		loader = before;
-		return [
-			this.loader(mergeOptions({remove: true}, options))
-		].concat(loader).join("!");
+ExtractTextPlugin.prototype.extract = function(options) {
+	if(arguments.length > 1) {
+		throw new Error("Deprecation notice: extract now only takes a single argument.\n" +
+				"Example: if your old code looked like this:\n" +
+				"    ExtractTextPlugin.extract('syle-loader', 'css-loader')\n\n" +
+				"You would change it to:\n" +
+				"    ExtractTextPlugin.extract({ notExtractLoader: 'syle-loader', loader: 'css-loader' })\n\n" +
+				"The available options are:\n" +
+				"    loader: string | object | loader[]\n" +
+				"    notExtractLoader: string | object | loader[]\n" +
+				"    publicPath: string\n");
 	}
+	var loader = options.loader;
+	var before = options.notExtractLoader || [];
+	if(isString(loader)) {
+		loader = loader.split("!");
+	}
+	if(isString(before)) {
+		before = before.split("!");
+	} else if(!Array.isArray(before)) {
+		before = [before];
+	}
+	options = mergeOptions({omit: before.length, extract: !!before.length, remove: !!before.length}, options);
+	delete options.loader;
+	delete options.notExtractLoader;
+	var loaders = [this.loader(options)].concat(before, loader);
+	if(loaders.every(isString)) {
+		loaders = loaders.join("!");
+	}
+	return loaders;
 };
 
 ExtractTextPlugin.extract = ExtractTextPlugin.prototype.extract.bind(ExtractTextPlugin);


### PR DESCRIPTION
I still need to sanity check the `loader` method and fix tests but would appreciate @sokra's eyes. Here are a summary of changes:

- Port original example to WebPack 2 runnable with `webpack --config webpack2.config.js` in the example directory with WebPack 2 in the path.
- Migrate API to accept single options object instead of variably ordered args. Arguably necessary to differentiate between loader and option objects.
- Delegate `extract`class function to instance method to eliminate copy pasta. Note that `loader` delegates the opposite direction.
- Add `isString` primarily to facilitate `if(loaders.every(isString))` but also repeated checks.
- Copy error message from `CommonChunksPlugin`.
- Minor changes to eliminate duplication in the conditional block.
- The output is potentially a `loaders` array instead of `loader` config. I need to think about how to surface that in API. Previously loaders were serialized to a single string using `join("!")`. Now that step is skipped in the presence of a query for WebPack 2 compatibility. My feel is to drop `loader` but there's no way to surface a migration error?