### PR TITLE
Be more specific on the peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Extract text from bundle into a file.",
   "peerDependencies": {
-    "webpack": "^2.1.0-beta"
+    "webpack": "^2.1.0-beta.19"
   },
   "dependencies": {
     "async": "^1.5.0",


### PR DESCRIPTION
This is not actually API-compatible with any webpack beta older than 2.1.0-beta.19.