### PR TITLE
Fix handling of loaders as objects without a query prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,8 @@ module.exports = ExtractTextPlugin;
 
 // modified from webpack/lib/LoadersList.js
 function getLoaderWithQuery(loader) {
-	if(isString(loader) || !loader.query) return loader;
+	if(isString(loader)) return loader;
+	if(!loader.query) return loader.loader;
 	var query = isString(loader.query) ? loader.query : JSON.stringify(loader.query);
 	return loader.loader + "?" + query;
 }

--- a/test/cases/simple-queryless-object/a.css
+++ b/test/cases/simple-queryless-object/a.css
@@ -1,0 +1,3 @@
+body {
+	correct: a;
+}

--- a/test/cases/simple-queryless-object/b.css
+++ b/test/cases/simple-queryless-object/b.css
@@ -1,0 +1,3 @@
+body {
+	correct: b;
+}

--- a/test/cases/simple-queryless-object/expected/file.css
+++ b/test/cases/simple-queryless-object/expected/file.css
@@ -1,0 +1,8 @@
+body {
+	correct: a;
+}
+body {
+	correct: b;
+}
+
+/*# sourceMappingURL=file.css.map*/

--- a/test/cases/simple-queryless-object/index.js
+++ b/test/cases/simple-queryless-object/index.js
@@ -1,0 +1,2 @@
+require("./a.css");
+require("./b.css");

--- a/test/cases/simple-queryless-object/webpack.config.js
+++ b/test/cases/simple-queryless-object/webpack.config.js
@@ -1,0 +1,18 @@
+var ExtractTextPlugin = require("../../../");
+module.exports = {
+	entry: "./index",
+	module: {
+		loaders: [
+			{ test: /\.css$/, loader: ExtractTextPlugin.extract({
+				fallbackLoader: { loader: "style-loader" },
+				loader: { loader: "css-loader", query: {
+					sourceMap: true
+				} }
+			}) }
+		]
+	},
+	devtool: "source-map",
+	plugins: [
+		new ExtractTextPlugin("file.css")
+	]
+};


### PR DESCRIPTION
If you provide a loader as an object *without* query config, the entire object currently gets returned from `getLoaderWithQuery()` and ends up being stringified as `[object Object]` in the final loader string generated.