### PR TITLE
Add info about order of rules in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ module.exports = {
 }
 ```
 
-It moves every `require("style.css")` in entry chunks into a separate css output file. So your styles are no longer inlined into the javascript, but separate in a css bundle file (`styles.css`). If your total stylesheet volume is big, it will be faster because the stylesheet bundle is loaded in parallel to the javascript bundle.
+It moves every `require("style.css")` in entry chunks into a separate css output file, based on the order the `require()` calls were encountered. So your styles are no longer inlined into the javascript, but separate in a css bundle file (`styles.css`). If your total stylesheet volume is big, it will be faster because the stylesheet bundle is loaded in parallel to the javascript bundle.
 
 Advantages:
 


### PR DESCRIPTION
The current README does not tell in which order the generated text will appear in the output file. Since the order of rules is important in CSS, we should add a note on this. It is also important that this behavior is currently based implicitly on the way webpack is ordering the modules.
