### PR TITLE
Allow webpack 2 rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Extract text from bundle into a file.",
   "peerDependencies": {
-    "webpack": "^2.1.0-beta.19"
+    "webpack": "^2.1.0-beta.19 || ^2.2.0-rc.0"
   },
   "dependencies": {
     "async": "^1.5.0",


### PR DESCRIPTION
Fixes this warning:

> warning Incorrect peer dependency "webpack@^2.1.0-beta.19".
