### PR TITLE
Bump `async`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "webpack": "^2.1.0-beta.19"
   },
   "dependencies": {
-    "async": "^1.5.0",
+    "async": "^2.1.2",
     "loader-utils": "^0.2.3",
     "webpack-sources": "^0.1.0"
   },


### PR DESCRIPTION
To match [the version](https://github.com/webpack/webpack/blob/master/package.json#L11) `webpack` uses.