### PR TITLE
Adds "webpack 2.2.0" as option for peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Extract text from bundle into a file.",
   "peerDependencies": {
-    "webpack": "^2.1.0-beta.19 || ^2.2.0-rc.0"
+    "webpack": "^2.1.0-beta.19 || ^2.2.0-rc.0 || 2.2.0"
   },
   "dependencies": {
     "async": "^2.1.2",


### PR DESCRIPTION
Resolves #346

Not sure if we can remove `^2.2.0-rc.0` from the `peerDependencies` altogether, but this does fix the related issue.